### PR TITLE
Ignore OS as an input to `GenerateProtoTask`

### DIFF
--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -379,6 +379,18 @@ public abstract class GenerateProtoTask extends DefaultTask {
     }
   }
 
+  @InputFiles
+  @PathSensitive(PathSensitivity.NONE)
+  FileCollection getExecutables() {
+    objectFactory.fileCollection().from {
+      protocLocator.getOrNull()?.path
+    }.from {
+      pluginsExecutableLocators.get().values()
+        .collect { it.path }
+        .findAll { it }
+    }
+  }
+
   @Internal("Input captured by getAlternativePaths()")
   abstract MapProperty<String, ExecutableLocator> getPluginsExecutableLocators()
 

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -324,16 +324,16 @@ public abstract class GenerateProtoTask extends DefaultTask {
     return variant
   }
 
-  @Internal("Input captured by getAlternativePaths()")
+  @Internal("Input captured by getExecutables()")
   abstract Property<ExecutableLocator> getProtocLocator()
 
-  @Internal("Input captured by getAlternativePaths(), this is used to query alternative path by locator name.")
+  @Internal("Input captured by getSnapshotArtifacts(), this is used to query alternative path by locator name.")
   abstract MapProperty<String, FileCollection> getLocatorToAlternativePathsMapping()
 
-  @Internal
+  @Internal("Input captured by getReleaseDependenciesMapping()")
   abstract MapProperty<String, String> getLocatorToDependencyMapping()
 
-  @Internal
+  @Internal("This property is no longer an input, but kept and marked @Internal for backwards compatibility.")
   ConfigurableFileCollection getAlternativePaths() {
     return objectFactory.fileCollection().from(getLocatorToAlternativePathsMapping().get().values())
   }
@@ -391,7 +391,7 @@ public abstract class GenerateProtoTask extends DefaultTask {
     }
   }
 
-  @Internal("Input captured by getAlternativePaths()")
+  @Internal("Input captured by getExecutables()")
   abstract MapProperty<String, ExecutableLocator> getPluginsExecutableLocators()
 
   @Internal("Not an actual input to the task, only used to find tasks belonging to a variant")

--- a/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/GenerateProtoTask.groovy
@@ -361,8 +361,8 @@ public abstract class GenerateProtoTask extends DefaultTask {
   @InputFiles
   @PathSensitive(PathSensitivity.NONE)
   FileCollection getSnapshotArtifacts() {
-    def snapshotArtifacts = locatorToAlternativePathsMapping.map { map ->
-      def releaseArtifactKeys = releaseDependenciesMapping.get().keySet()
+    Provider<Collection<FileCollection>> snapshotArtifacts = locatorToAlternativePathsMapping.map { map ->
+      Set<String> releaseArtifactKeys = releaseDependenciesMapping.get().keySet()
       map.findAll { entry ->
         !releaseArtifactKeys.contains(entry.key)
       }.values()

--- a/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
+++ b/src/main/groovy/com/google/protobuf/gradle/ToolsLocator.groovy
@@ -112,6 +112,7 @@ class ToolsLocator {
     for (GenerateProtoTask protoTask in protoTasks) {
       if (protoc.is(locator) || protoTask.hasPlugin(locator.name)) {
         protoTask.locatorToAlternativePathsMapping.put(locator.name, artifactFiles)
+        protoTask.locatorToDependencyMapping.put(locator.name, "$groupId:$artifact:$version".toString())
       }
     }
   }

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -415,6 +415,76 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
+  void "test proto generation is not up-to-date on dependency changes [gradle #gradleVersion]"() {
+    given: "project from testProject"
+    File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
+            .copyDirs('testProjectBase', 'testProject')
+            .build()
+
+    when: "build is invoked"
+    BuildResult result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments('build', '--stacktrace')
+            .withPluginClasspath()
+            .withGradleVersion(gradleVersion)
+            .forwardStdOutput(new OutputStreamWriter(System.out))
+            .forwardStdError(new OutputStreamWriter(System.err))
+            .withDebug(true)
+            .build()
+
+    then: "it succeeds"
+    result.task(":build").outcome == TaskOutcome.SUCCESS
+
+    when: "protoc artifact is changed and build runs again"
+    new File(projectDir, "build.gradle")
+            .append("""
+              protobuf {
+                protoc {
+                  artifact = 'com.google.protobuf:protoc:3.0.2'
+                }
+              }""")
+    result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments('build', '--stacktrace')
+            .withPluginClasspath()
+            .withGradleVersion(gradleVersion)
+            .forwardStdOutput(new OutputStreamWriter(System.out))
+            .forwardStdError(new OutputStreamWriter(System.err))
+            .withDebug(true)
+            .build()
+
+    then: "generateProto is not UP_TO_DATE"
+    result.task(":generateProto").outcome == TaskOutcome.SUCCESS
+
+
+    when: "plugin artifact is changed and build runs again"
+    new File(projectDir, "build.gradle")
+            .append("""
+              protobuf {
+                plugins {
+                  grpc {
+                    artifact = 'io.grpc:protoc-gen-grpc-java:1.0.3'
+                  }
+                }
+              }""")
+    result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments('build', '--stacktrace')
+            .withPluginClasspath()
+            .withGradleVersion(gradleVersion)
+            .forwardStdOutput(new OutputStreamWriter(System.out))
+            .forwardStdError(new OutputStreamWriter(System.err))
+            .withDebug(true)
+            .build()
+
+    then: "generateProto is not UP_TO_DATE"
+    result.task(":generateGrpcProto").outcome == TaskOutcome.SUCCESS
+
+    where:
+    gradleVersion << GRADLE_VERSIONS
+  }
+
+  @Unroll
   void "test proto extraction is up-to-date for testProject when changing java sources [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -485,6 +485,61 @@ class ProtobufJavaPluginTest extends Specification {
   }
 
   @Unroll
+  void "test proto generation is not up-to-date on path changes [gradle #gradleVersion]"() {
+    given: "project from testProject"
+    File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')
+            .copyDirs('testProjectBase', 'testProject')
+            .build()
+
+    when: "protoc path is set and build is invoked"
+    def buildGradleFile = new File(projectDir, "build.gradle")
+    buildGradleFile.append("""
+        configurations {
+          protoc
+        }
+
+        dependencies {
+          protoc "com.google.protobuf:protoc:3.0.0:\$project.osdetector.classifier@exe"
+        }
+        
+        protobuf {
+          protoc {
+            path = "\$configurations.protoc.singleFile"
+          }
+        }""")
+    def result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments('build', '--stacktrace')
+            .withPluginClasspath()
+            .withGradleVersion(gradleVersion)
+            .forwardStdOutput(new OutputStreamWriter(System.out))
+            .forwardStdError(new OutputStreamWriter(System.err))
+            .withDebug(true)
+            .build()
+
+    then: "it succeeds"
+    result.task(":generateProto").outcome == TaskOutcome.SUCCESS
+
+    when: "protoc path is changed and build runs again"
+    buildGradleFile.text = buildGradleFile.text.replace("com.google.protobuf:protoc:3.0.0", "com.google.protobuf:protoc:3.0.2")
+    result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments('build', '--stacktrace')
+            .withPluginClasspath()
+            .withGradleVersion(gradleVersion)
+            .forwardStdOutput(new OutputStreamWriter(System.out))
+            .forwardStdError(new OutputStreamWriter(System.err))
+            .withDebug(true)
+            .build()
+
+    then: "generateProto is not UP_TO_DATE"
+    result.task(":generateProto").outcome == TaskOutcome.SUCCESS
+
+    where:
+    gradleVersion << GRADLE_VERSIONS
+  }
+
+  @Unroll
   void "test proto extraction is up-to-date for testProject when changing java sources [gradle #gradleVersion]"() {
     given: "project from testProject"
     File projectDir = ProtobufPluginTestHelper.projectBuilder('testProject')

--- a/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
+++ b/src/test/groovy/com/google/protobuf/gradle/ProtobufJavaPluginTest.groovy
@@ -456,7 +456,6 @@ class ProtobufJavaPluginTest extends Specification {
     then: "generateProto is not UP_TO_DATE"
     result.task(":generateProto").outcome == TaskOutcome.SUCCESS
 
-
     when: "plugin artifact is changed and build runs again"
     new File(projectDir, "build.gradle")
             .append("""
@@ -492,7 +491,7 @@ class ProtobufJavaPluginTest extends Specification {
             .build()
 
     when: "protoc path is set and build is invoked"
-    def buildGradleFile = new File(projectDir, "build.gradle")
+    File buildGradleFile = new File(projectDir, "build.gradle")
     buildGradleFile.append("""
         configurations {
           protoc
@@ -501,13 +500,13 @@ class ProtobufJavaPluginTest extends Specification {
         dependencies {
           protoc "com.google.protobuf:protoc:3.0.0:\$project.osdetector.classifier@exe"
         }
-        
+
         protobuf {
           protoc {
             path = "\$configurations.protoc.singleFile"
           }
         }""")
-    def result = GradleRunner.create()
+    BuildResult result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments('build', '--stacktrace')
             .withPluginClasspath()
@@ -521,7 +520,8 @@ class ProtobufJavaPluginTest extends Specification {
     result.task(":generateProto").outcome == TaskOutcome.SUCCESS
 
     when: "protoc path is changed and build runs again"
-    buildGradleFile.text = buildGradleFile.text.replace("com.google.protobuf:protoc:3.0.0", "com.google.protobuf:protoc:3.0.2")
+    buildGradleFile.text = buildGradleFile.text.replace("com.google.protobuf:protoc:3.0.0",
+        "com.google.protobuf:protoc:3.0.2")
     result = GradleRunner.create()
             .withProjectDir(projectDir)
             .withArguments('build', '--stacktrace')


### PR DESCRIPTION
This change will remove the OS from the input properties of the
GenerateProtoTask when `protoc` or a plugin is defined as a resolvable
artifact. The expectation is that same versions of `protoc` or plugins
will produce same outputs regardless of the OS on which they are run.

This is done by creating marking `alternativePaths` as Internal for
backwards compatibility and creating two new properties:
`releaseArtifacts` and `snapshotArtifacts`. `releaseArtifacts` will
contain "$groupId:$artifact:$version" for each non-snapshot dependency,
effectively ignoring OS for these dependencies. `snapshotArtifacts` will
contain each snapshot artifact in a `FileCollection` since the
snapshots cannot be matched solely by their maven coordinates.